### PR TITLE
Hide console window for GUI release builds

### DIFF
--- a/crates/psu-packer-gui/src/main.rs
+++ b/crates/psu-packer-gui/src/main.rs
@@ -1,3 +1,5 @@
+#![cfg_attr(not(debug_assertions), windows_subsystem = "windows")]
+
 use eframe::egui;
 use std::path::PathBuf;
 


### PR DESCRIPTION
## Summary
- add a `windows_subsystem = "windows"` attribute so the release GUI binary launches without a console window

## Testing
- cargo build -p psu-packer-gui --release

------
https://chatgpt.com/codex/tasks/task_e_68c84005b34c8321a25eb372d9397f9a