### PR TITLE
Add PSU metadata editing to GUI

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4088,9 +4088,11 @@ dependencies = [
 name = "psu-packer-gui"
 version = "0.1.0"
 dependencies = [
+ "chrono",
  "eframe 0.27.2",
  "psu-packer",
  "rfd 0.14.1",
+ "toml_edit 0.22.24",
 ]
 
 [[package]]

--- a/crates/psu-packer-gui/Cargo.toml
+++ b/crates/psu-packer-gui/Cargo.toml
@@ -8,3 +8,5 @@ version.workspace = true
 psu-packer = { path = "../psu-packer" }
 eframe = "0.27"
 rfd = "0.14"
+chrono = "0.4.42"
+toml_edit = "0.22"

--- a/crates/psu-packer-gui/src/main.rs
+++ b/crates/psu-packer-gui/src/main.rs
@@ -1,12 +1,18 @@
 #![cfg_attr(not(debug_assertions), windows_subsystem = "windows")]
 
+use chrono::NaiveDateTime;
 use eframe::egui;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
+use toml_edit::{value, DocumentMut};
+
+const TIMESTAMP_FORMAT: &str = "%Y-%m-%d %H:%M:%S";
 
 struct PackerApp {
     folder: Option<PathBuf>,
     output: String,
     status: String,
+    name: String,
+    timestamp: String,
 }
 
 impl Default for PackerApp {
@@ -15,7 +21,46 @@ impl Default for PackerApp {
             folder: None,
             output: String::new(),
             status: String::new(),
+            name: String::new(),
+            timestamp: String::new(),
         }
+    }
+}
+
+impl PackerApp {
+    fn save_config(&self, folder: &Path) -> Result<(), String> {
+        let config_path = folder.join("psu.toml");
+        let config_str = std::fs::read_to_string(&config_path)
+            .map_err(|e| format!("Failed to read {}: {e}", config_path.display()))?;
+        let mut document = config_str
+            .parse::<DocumentMut>()
+            .map_err(|e| format!("Failed to parse {}: {e}", config_path.display()))?;
+
+        let Some(config_item) = document.get_mut("config") else {
+            return Err("psu.toml is missing a [config] section".to_string());
+        };
+        let Some(config_table) = config_item.as_table_mut() else {
+            return Err("psu.toml [config] section is not a table".to_string());
+        };
+
+        config_table.insert("name", value(self.name.clone()));
+
+        let timestamp = self.timestamp.trim();
+        if timestamp.is_empty() {
+            config_table.remove("timestamp");
+        } else {
+            let parsed = NaiveDateTime::parse_from_str(timestamp, TIMESTAMP_FORMAT)
+                .map_err(|e| format!("Invalid timestamp: {e}"))?;
+            config_table.insert(
+                "timestamp",
+                value(parsed.format(TIMESTAMP_FORMAT).to_string()),
+            );
+        }
+
+        std::fs::write(&config_path, document.to_string())
+            .map_err(|e| format!("Failed to write {}: {e}", config_path.display()))?;
+
+        Ok(())
     }
 }
 
@@ -24,14 +69,38 @@ impl eframe::App for PackerApp {
         egui::CentralPanel::default().show(ctx, |ui| {
             if ui.button("Select folder").clicked() {
                 if let Some(dir) = rfd::FileDialog::new().pick_folder() {
-                    if let Ok(config) = psu_packer::load_config(&dir) {
-                        self.output = format!("{}.psu", config.name);
+                    match psu_packer::load_config(&dir) {
+                        Ok(config) => {
+                            self.output = format!("{}.psu", config.name);
+                            self.name = config.name;
+                            self.timestamp = config
+                                .timestamp
+                                .map(|t| t.format(TIMESTAMP_FORMAT).to_string())
+                                .unwrap_or_default();
+                            self.status.clear();
+                        }
+                        Err(err) => {
+                            self.status = format!("Error loading config: {err}");
+                            self.output.clear();
+                            self.name.clear();
+                            self.timestamp.clear();
+                        }
                     }
                     self.folder = Some(dir);
                 }
             }
             if let Some(folder) = &self.folder {
                 ui.label(format!("Folder: {}", folder.display()));
+            }
+            if !self.name.is_empty() || self.folder.is_some() {
+                ui.horizontal(|ui| {
+                    ui.label("Name:");
+                    ui.text_edit_singleline(&mut self.name);
+                });
+                ui.horizontal(|ui| {
+                    ui.label("Timestamp:");
+                    ui.text_edit_singleline(&mut self.timestamp);
+                });
             }
             ui.horizontal(|ui| {
                 ui.label("Output:");
@@ -47,6 +116,16 @@ impl eframe::App for PackerApp {
             });
             if ui.button("Pack").clicked() {
                 if let Some(folder) = &self.folder {
+                    if self.name.trim().is_empty() {
+                        self.status = "Please provide a PSU name".to_string();
+                        return;
+                    }
+
+                    if let Err(err) = self.save_config(folder) {
+                        self.status = err;
+                        return;
+                    }
+
                     let output_path = PathBuf::from(&self.output);
                     match psu_packer::pack_psu(folder, &output_path) {
                         Ok(_) => self.status = format!("Packed to {}", output_path.display()),


### PR DESCRIPTION
## Summary
- add PSU name and timestamp fields to the GUI and persist them to psu.toml before packing
- load existing metadata when selecting a folder and validate timestamp formatting
- pull in chrono and toml_edit for date handling and toml updates

## Testing
- cargo check


------
https://chatgpt.com/codex/tasks/task_e_68c84a0395408321990dff96b82af6ba