### PR TITLE
Allow packing with in-memory configuration

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4092,7 +4092,6 @@ dependencies = [
  "eframe 0.27.2",
  "psu-packer",
  "rfd 0.14.1",
- "toml_edit 0.22.24",
 ]
 
 [[package]]

--- a/crates/psu-packer-gui/Cargo.toml
+++ b/crates/psu-packer-gui/Cargo.toml
@@ -9,4 +9,3 @@ psu-packer = { path = "../psu-packer" }
 eframe = "0.27"
 rfd = "0.14"
 chrono = "0.4.42"
-toml_edit = "0.22"


### PR DESCRIPTION
## Summary
- add a new `pack_with_config` helper in psu-packer so packing logic can reuse a provided Config
- keep `pack_psu` focused on loading psu.toml then calling the shared helper
- update the GUI to build the Config in memory and call `pack_with_config`, removing the toml_edit dependency

## Testing
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_68c860643e5c8321835452c28a54d8be